### PR TITLE
Remove the /tmp cleanup

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,9 +99,6 @@ jobs:
       conda remove -n TorchDetectAML --all -q --force -y
       conda env list
 
-      echo Clean /tmp
-      sudo rm -fr /tmp
-
       echo Ensure Resource Group Deletion
       existResponse=$(az group exists -n $(azureresourcegroup))
       if [ "$existResponse" == "true" ]; then


### PR DESCRIPTION
Interesting issue where build agent stopped responding and I suspect something to do with the /tmp directory being completely cleaned up before the build even completes.