### PR TITLE
remove cocoapi directory before cloning, undo numpy pinning to 1.17

### DIFF
--- a/03_BuildDockerImage.ipynb
+++ b/03_BuildDockerImage.ipynb
@@ -107,7 +107,6 @@
     "# RUN pip install --upgrade pip && \\\n",
     "RUN pip install azureml-sdk[notebooks] && \\\n",
     "    pip install Pillow==6.1 && \\\n",
-    "    pip install numpy==1.17 && \\\n",
     "    /opt/conda/bin/conda clean -yt\n",
     "\n",
     "RUN git clone https://github.com/cocodataset/cocoapi.git && \\\n",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,7 @@ jobs:
       
       echo Get Data Files 
       cd scripts
+      rm -rf cocoapi
       git clone https://github.com/cocodataset/cocoapi.git
       cd cocoapi/PythonAPI
       make

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,5 @@ dependencies:
     - papermill==1.1.0
     - python-dotenv==0.10.1
     - Pillow==6.1
-    - numpy==1.17
     - azure-cli
     


### PR DESCRIPTION
cocoapi already fixes issue with numpy so unpin numpy and make sure cocoapi is removed before cloning,